### PR TITLE
[PPP-4848] commons-net library has a vulnerability, but is not called by

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <mail.version>1.6.1</mail.version>
-    <commons-net.version>1.4.1</commons-net.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <oro.version>2.0.8</oro.version>
     <commons-collections.version>3.2.2</commons-collections.version>
@@ -46,18 +45,6 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-net</groupId>
-      <artifactId>commons-net</artifactId>
-      <version>${commons-net.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
any java code in this repository.  We only seem to use it as an FTP file provider, so moving this dependency to where it's needed as cleanup.